### PR TITLE
Fix token request body building

### DIFF
--- a/src/Service/IntrospectionService.php
+++ b/src/Service/IntrospectionService.php
@@ -50,10 +50,8 @@ final class IntrospectionService
         $tokenRequest = $this->requestFactory->createRequest('POST', $endpointUri)
             ->withHeader('content-type', 'application/x-www-form-urlencoded');
 
+        $params['token'] = $token;
         $tokenRequest = $authMethod->createRequest($tokenRequest, $client, $params);
-        $tokenRequest->getBody()->write(http_build_query(array_merge($params, [
-            'token' => $token,
-        ])));
 
         $httpClient = $client->getHttpClient() ?? $this->client;
 

--- a/src/Service/RevocationService.php
+++ b/src/Service/RevocationService.php
@@ -48,10 +48,8 @@ final class RevocationService
         $tokenRequest = $this->requestFactory->createRequest('POST', $endpointUri)
             ->withHeader('content-type', 'application/x-www-form-urlencoded');
 
+        $params['token'] = $token;
         $tokenRequest = $authMethod->createRequest($tokenRequest, $client, $params);
-        $tokenRequest->getBody()->write(http_build_query(array_merge($params, [
-            'token' => $token,
-        ])));
 
         $httpClient = $client->getHttpClient() ?? $this->client;
 


### PR DESCRIPTION
This PR:

- [x] Fix the body building of the token request.
- [x] Relates to #1
- [x] Provide a fix, but I would like to have a review/confirmation from @thomasvargiu  

The bug has been discovered by my colleage @ileanatudoran, props to her!

How to reproduce the issue?

When you want to introspect the access token using `client_secret_jwt`, the `IntrospectionService` seems to be your friend.
Inside `IntrospectionService::introspect()`, the `ClientSecretJwt AuthMethodInterface` calls `AbstractJwtAuth::createRequest()`

```php
$tokenRequest = $authMethod->createRequest($tokenRequest, $client, $params);
```

and do:

```php
$clientId = $client->getMetadata()->getClientId();

$claims = array_merge([
    'client_id' => $clientId,
    'client_assertion_type' => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
    'client_assertion' => $this->createAuthJwt($client, $claims),
], $claims);

$request->getBody()->write(http_build_query($claims));
```

Then, that `$request` object is returned back in `IntrospectionService::introspect()` and the body of the `$request` is modified:

```php
$tokenRequest = $authMethod->createRequest($tokenRequest, $client, $params);
$tokenRequest->getBody()->write(http_build_query(array_merge($params, [
    'token' => $token,
])));
```

The issue is when we do:

```php
$tokenRequest->getBody()->write(http_build_query(array_merge($params, [
    'token' => $token,
])));
```

By using the `write()` method, it will append the generated query string to the `$request` body.

So, you could end up having a request body as such:

`client_assertion=tokenvalue&client_id=value1&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearertoken=token`

There is a missing `&` betweem the original request body `client_assertion=tokenvalue&client_id=value1&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer` and `token=token`.