### PR TITLE
Fix introspection endpoint.

### DIFF
--- a/src/Service/IntrospectionService.php
+++ b/src/Service/IntrospectionService.php
@@ -45,7 +45,7 @@ final class IntrospectionService
         $endpointUri = get_endpoint_uri($client, 'introspection_endpoint');
 
         $authMethod = $client->getAuthMethodFactory()
-            ->create($client->getMetadata()->getRevocationEndpointAuthMethod());
+            ->create($client->getMetadata()->getIntrospectionEndpointAuthMethod());
 
         $tokenRequest = $this->requestFactory->createRequest('POST', $endpointUri)
             ->withHeader('content-type', 'application/x-www-form-urlencoded');


### PR DESCRIPTION
The `IntrospectionService` use the `getRevocationEndpointAuthMethod()` instead of `getIntrospectionEndpointAuthMethod()`.

This PR:

- [x] Fix the method call.