### PR TITLE
Update consistency in builders setters.

### DIFF
--- a/src/Issuer/Metadata/Provider/MetadataProviderBuilder.php
+++ b/src/Issuer/Metadata/Provider/MetadataProviderBuilder.php
@@ -48,7 +48,7 @@ class MetadataProviderBuilder
         return $this;
     }
 
-    public function setClient(?ClientInterface $client): self
+    public function setHttpClient(?ClientInterface $client): self
     {
         $this->client = $client;
 

--- a/src/Issuer/Metadata/Provider/MetadataProviderBuilder.php
+++ b/src/Issuer/Metadata/Provider/MetadataProviderBuilder.php
@@ -41,6 +41,13 @@ class MetadataProviderBuilder
         return $this;
     }
 
+    public function setHttpClient(?ClientInterface $client): self
+    {
+        $this->client = $client;
+
+        return $this;
+    }
+
     public function setWebFingerProvider(WebFingerProviderInterface $webFingerProvider): self
     {
         $this->webFingerProvider = $webFingerProvider;
@@ -48,7 +55,10 @@ class MetadataProviderBuilder
         return $this;
     }
 
-    public function setHttpClient(?ClientInterface $client): self
+    /**
+     * @deprecated Use MetadataProviderBuilder::setHttpClient() instead.
+     */
+    public function setClient(?ClientInterface $client): self
     {
         $this->client = $client;
 


### PR DESCRIPTION
In order to have a consistency across all the builders,

I propose to:

- [x] Rename `MetadataProviderBuilder::setClient()` into `MetadataProviderBuilder::setHttpClient()` 
