### PR TITLE
Provide the aud claim in introspection - if it is not set by default

### DIFF
--- a/src/AuthMethod/ClientSecretJwt.php
+++ b/src/AuthMethod/ClientSecretJwt.php
@@ -78,8 +78,8 @@ final class ClientSecretJwt extends AbstractJwtAuth
         $jti = base64url_encode(random_bytes(32));
 
         /** @var string $payload */
-        $payload = json_encode(array_merge(
-            $claims,
+        $payload = json_encode(
+            $claims +
             [
                 'iss' => $clientId,
                 'sub' => $clientId,
@@ -88,7 +88,7 @@ final class ClientSecretJwt extends AbstractJwtAuth
                 'exp' => $time + 60,
                 'jti' => $jti,
             ]
-        ));
+        );
 
         $jws = $this->getJwsBuilder()->create()
             ->withPayload($payload)

--- a/src/Service/IntrospectionService.php
+++ b/src/Service/IntrospectionService.php
@@ -50,7 +50,10 @@ final class IntrospectionService
         $tokenRequest = $this->requestFactory->createRequest('POST', $endpointUri)
             ->withHeader('content-type', 'application/x-www-form-urlencoded');
 
-        $params['token'] = $token;
+        $params += [
+            'token' => $token,
+            'aud' => $client->getIssuer()->getMetadata()->getIntrospectionEndpoint(),
+        ];
         $tokenRequest = $authMethod->createRequest($tokenRequest, $client, $params);
 
         $httpClient = $client->getHttpClient() ?? $this->client;


### PR DESCRIPTION
This PR:

- [x] Provides the `aud` claim in the token if it is not set by default.