### PR TITLE
Change client assertion JWT aud claim to match token endpoint

### DIFF
--- a/src/AuthMethod/ClientSecretJwt.php
+++ b/src/AuthMethod/ClientSecretJwt.php
@@ -9,6 +9,7 @@ use function Facile\OpenIDClient\base64url_encode;
 use Facile\OpenIDClient\Client\ClientInterface as OpenIDClient;
 use Facile\OpenIDClient\Exception\InvalidArgumentException;
 use Facile\OpenIDClient\Exception\LogicException;
+use function Facile\OpenIDClient\get_endpoint_uri;
 use function Facile\OpenIDClient\jose_secret_key;
 use Jose\Component\Core\AlgorithmManager;
 use Jose\Component\Signature\Algorithm\HS256;
@@ -77,7 +78,7 @@ final class ClientSecretJwt extends AbstractJwtAuth
             [
                 'iss' => $clientId,
                 'sub' => $clientId,
-                'aud' => $issuerMetadata->getIssuer(),
+                'aud' => get_endpoint_uri($client, 'token_endpoint'),
                 'iat' => $time,
                 'exp' => $time + 60,
                 'jti' => $jti,

--- a/src/AuthMethod/ClientSecretJwt.php
+++ b/src/AuthMethod/ClientSecretJwt.php
@@ -66,8 +66,6 @@ final class ClientSecretJwt extends AbstractJwtAuth
         }
 
         $clientId = $client->getMetadata()->getClientId();
-        $issuer = $client->getIssuer();
-        $issuerMetadata = $issuer->getMetadata();
 
         $jwk = jose_secret_key($clientSecret);
 

--- a/src/AuthMethod/PrivateKeyJwt.php
+++ b/src/AuthMethod/PrivateKeyJwt.php
@@ -58,9 +58,6 @@ final class PrivateKeyJwt extends AbstractJwtAuth
      */
     protected function createAuthJwt(OpenIDClient $client, array $claims = []): string
     {
-        $issuer = $client->getIssuer();
-        $issuerMetadata = $issuer->getMetadata();
-
         $clientId = $client->getMetadata()->getClientId();
 
         $jwk = $this->jwk ?? JWKSet::createFromKeyData($client->getJwksProvider()->getJwks())->selectKey('sig');

--- a/src/AuthMethod/PrivateKeyJwt.php
+++ b/src/AuthMethod/PrivateKeyJwt.php
@@ -14,6 +14,7 @@ use Jose\Component\Core\JWKSet;
 use Jose\Component\Signature\JWSBuilder;
 use Jose\Component\Signature\Serializer\CompactSerializer;
 use Jose\Component\Signature\Serializer\JWSSerializer;
+use function Facile\OpenIDClient\get_endpoint_uri;
 use function json_encode;
 use function random_bytes;
 use function time;
@@ -76,7 +77,7 @@ final class PrivateKeyJwt extends AbstractJwtAuth
             [
                 'iss' => $clientId,
                 'sub' => $clientId,
-                'aud' => $issuerMetadata->getIssuer(),
+                'aud' => get_endpoint_uri($client, 'token_endpoint'),
                 'iat' => $time,
                 'exp' => $time + $this->tokenTTL,
                 'jti' => $jti,


### PR DESCRIPTION
I am using this library to integrate with Okta using the `client_secret_jwt` auth method and I got this error from Okta:

> The audience claim for client_assertion must be the endpoint invoked for the request.

The code was using the issuer url (example: https://foo.okta.com) but Okta is expecting it to be the same as the token endpoint url such as https://foo.okta.com/oauth2/v1/token

https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication

> The aud (audience) Claim. Value that identifies the Authorization Server as an intended audience. The Authorization Server MUST verify that it is an intended audience for the token. The Audience SHOULD be the URL of the Authorization Server's Token Endpoint.
