### PR TITLE
Support authorization endpoint containing query params

### DIFF
--- a/src/Service/AuthorizationService.php
+++ b/src/Service/AuthorizationService.php
@@ -122,7 +122,14 @@ final class AuthorizationService
             throw new InvalidArgumentException('nonce MUST be provided for implicit and hybrid flows');
         }
 
-        return $endpointUri . '?' . http_build_query($params);
+        // Support Authorization Endpoint uris with query params
+        $splitUrl = explode('?', $endpointUri);
+        if (isset($splitUrl[1])) {
+            parse_str($splitUrl[1], $existingParameters);
+            $params = array_merge($existingParameters, $params);
+        }
+
+        return $splitUrl[0] . '?' . http_build_query($params);
     }
 
     /**

--- a/src/Service/AuthorizationService.php
+++ b/src/Service/AuthorizationService.php
@@ -123,7 +123,7 @@ final class AuthorizationService
         }
 
         // Support Authorization Endpoint uris with query params
-        $splitUrl = explode('?', $endpointUri);
+        $splitUrl = explode('?', $endpointUri, 2);
         if (isset($splitUrl[1])) {
             parse_str($splitUrl[1], $existingParameters);
             $params = array_merge($existingParameters, $params);

--- a/tests/Service/AuthorizationServiceTest.php
+++ b/tests/Service/AuthorizationServiceTest.php
@@ -54,9 +54,12 @@ class AuthorizationServiceTest extends TestCase
         $clientMetadata->getResponseTypes()->willReturn(['code']);
         $clientMetadata->getRedirectUris()->willReturn(['redirect_uri_1']);
         $issuer->getMetadata()->willReturn($issuerMetadata);
-        $issuerMetadata->getAuthorizationEndpoint()->willReturn('https://foo-endpoint');
+        $issuerMetadata->getAuthorizationEndpoint()->willReturn('https://foo-endpoint?param=value');
 
-        static::assertSame('https://foo-endpoint?client_id=clientId&scope=openid&response_type=code&redirect_uri=redirect_uri_1', $service->getAuthorizationUri($openIdClient->reveal()));
+        static::assertSame(
+            'https://foo-endpoint?param=value&client_id=clientId&scope=openid&response_type=code&redirect_uri=redirect_uri_1',
+            $service->getAuthorizationUri($openIdClient->reveal())
+        );
     }
 
     public function testFetchTokenFromCode(): void

--- a/tests/Service/AuthorizationServiceTest.php
+++ b/tests/Service/AuthorizationServiceTest.php
@@ -54,6 +54,42 @@ class AuthorizationServiceTest extends TestCase
         $clientMetadata->getResponseTypes()->willReturn(['code']);
         $clientMetadata->getRedirectUris()->willReturn(['redirect_uri_1']);
         $issuer->getMetadata()->willReturn($issuerMetadata);
+        $issuerMetadata->getAuthorizationEndpoint()->willReturn('https://foo-endpoint');
+
+        static::assertSame(
+            'https://foo-endpoint?client_id=clientId&scope=openid&response_type=code&redirect_uri=redirect_uri_1',
+            $service->getAuthorizationUri($openIdClient->reveal())
+        );
+    }
+
+    public function testGetAuthorizationUriWithParameters(): void
+    {
+        $tokenSetFactory = $this->prophesize(TokenSetFactoryInterface::class);
+        $client = $this->prophesize(ClientInterface::class);
+        $requestFactory = $this->prophesize(RequestFactoryInterface::class);
+        $idTokenVerifierBuilder = $this->prophesize(IdTokenVerifierBuilderInterface::class);
+        $tokenVerifierBuilder = $this->prophesize(TokenVerifierBuilderInterface::class);
+
+        $service = new AuthorizationService(
+            $tokenSetFactory->reveal(),
+            $client->reveal(),
+            $requestFactory->reveal(),
+            $idTokenVerifierBuilder->reveal(),
+            $tokenVerifierBuilder->reveal()
+        );
+
+        $openIdClient = $this->prophesize(OpenIDClient::class);
+        $clientMetadata = $this->prophesize(ClientMetadataInterface::class);
+        $issuer = $this->prophesize(IssuerInterface::class);
+        $issuerMetadata = $this->prophesize(IssuerMetadataInterface::class);
+
+        $openIdClient->getIssuer()->willReturn($issuer->reveal());
+        $openIdClient->getMetadata()->willReturn($clientMetadata->reveal());
+        $openIdClient->getHttpClient()->willReturn(null);
+        $clientMetadata->getClientId()->willReturn('clientId');
+        $clientMetadata->getResponseTypes()->willReturn(['code']);
+        $clientMetadata->getRedirectUris()->willReturn(['redirect_uri_1']);
+        $issuer->getMetadata()->willReturn($issuerMetadata);
         $issuerMetadata->getAuthorizationEndpoint()->willReturn('https://foo-endpoint?param=value');
 
         static::assertSame(


### PR DESCRIPTION
Right now, if the well-known url provides an authorization endpoint containing a query, the `AuthorizationService` will build a wrong url, which will eventually contains the symbol `?` twice.

This PR adds the unit test to spot the case, so adds some checks on the uri generation in order to prevent the problem.
Even better would be to have to separate tests, one for the uri containing params and one for the uri without params, but this is up to you.

I wasn't able to perform a `composer run psalm` before opening the PR since it looks broken, I am sorry.