### PR TITLE
Update 'psr/http-message' allowed version to ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-factory-implementation": "^1.0",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "psr/http-message-implementation": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "web-token/jwt-checker": "^2.0 || ^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1f2543db2fdb1248d6fdbfdc9faaa70b",
+    "content-hash": "9d923efbf3fd7a6326757d9b9235513a",
     "packages": [
         {
             "name": "brick/math",
@@ -8774,5 +8774,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Hi,

My previous MR got automatically closed while updating the fork, so I've had to open a new one.
https://github.com/facile-it/php-openid-client/pull/28

I've only updated the package versions allowed, PSALM is giving some errors I can't figure out easily, also before adding any changes. Strangely enough, it isn't capable of finding one of the Algorithms (EdDSA) even when it is clearly present. 

